### PR TITLE
Review/metadata persistence

### DIFF
--- a/src/java/org/apache/cassandra/service/accord/AccordKeyspace.java
+++ b/src/java/org/apache/cassandra/service/accord/AccordKeyspace.java
@@ -542,12 +542,12 @@ public class AccordKeyspace
         return TupleType.buildValue(new ByteBuffer[]{bytes(timestamp.epoch), bytes(timestamp.real), bytes(timestamp.logical), bytes(timestamp.node.id)});
     }
 
-    private interface TimestampFactory<T extends Timestamp>
+    public interface TimestampFactory<T extends Timestamp>
     {
         T create(long epoch, long real, int logical, Node.Id node);
     }
 
-    private static <T extends Timestamp> T deserializeTimestampOrNull(ByteBuffer bytes, TimestampFactory<T> factory)
+    public static <T extends Timestamp> T deserializeTimestampOrNull(ByteBuffer bytes, TimestampFactory<T> factory)
     {
         if (bytes == null || ByteBufferAccessor.instance.isEmpty(bytes))
             return null;

--- a/src/java/org/apache/cassandra/service/accord/db/AccordUpdate.java
+++ b/src/java/org/apache/cassandra/service/accord/db/AccordUpdate.java
@@ -138,7 +138,7 @@ public class AccordUpdate implements Update
 
         public boolean applies(FilteredPartition partition)
         {
-            return applies(partition.getRow(clustering));
+            return applies(partition == null ? null : partition.getRow(clustering));
         }
 
         public boolean supportedByRead(SinglePartitionReadCommand read)

--- a/test/distributed/org/apache/cassandra/distributed/test/accord/AccordIntegrationTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/accord/AccordIntegrationTest.java
@@ -28,7 +28,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -71,7 +70,6 @@ import org.apache.cassandra.service.accord.AccordService;
 import org.apache.cassandra.service.accord.AccordTxnBuilder;
 import org.apache.cassandra.service.accord.db.AccordData;
 import org.apache.cassandra.utils.ByteBufferUtil;
-import org.apache.cassandra.utils.Clock;
 import org.apache.cassandra.utils.FailingConsumer;
 import org.assertj.core.api.Assertions;
 

--- a/test/distributed/org/apache/cassandra/distributed/test/accord/AccordIntegrationTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/accord/AccordIntegrationTest.java
@@ -290,7 +290,7 @@ public class AccordIntegrationTest extends TestBaseImpl
 
     private static void awaitAsyncApply(Cluster cluster) throws TimeoutException
     {
-        long deadlineNanos = nanoTime() + TimeUnit.SECONDS.toNanos(1);
+        long deadlineNanos = nanoTime() + TimeUnit.SECONDS.toNanos(30);
         AtomicReference<TimeoutException> timeout = new AtomicReference<>(null);
         cluster.stream().filter(i -> !i.isShutdown()).forEach(inst -> {
             while (timeout.get() == null)

--- a/test/distributed/org/apache/cassandra/distributed/test/accord/AccordIntegrationTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/accord/AccordIntegrationTest.java
@@ -26,6 +26,8 @@ import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
@@ -36,9 +38,14 @@ import com.google.common.util.concurrent.Uninterruptibles;
 import org.junit.Assert;
 import org.junit.Test;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import accord.coordinate.Preempted;
+import accord.local.Status;
 import accord.messages.Commit;
 import accord.primitives.Keys;
+import accord.primitives.TxnId;
 import accord.topology.Topologies;
 import accord.txn.Txn;
 import org.apache.cassandra.cql3.statements.SelectStatement;
@@ -54,23 +61,30 @@ import org.apache.cassandra.distributed.api.SimpleQueryResult;
 import org.apache.cassandra.distributed.impl.Instance;
 import org.apache.cassandra.distributed.shared.AssertUtils;
 import org.apache.cassandra.distributed.test.TestBaseImpl;
+import org.apache.cassandra.distributed.util.QueryResultUtil;
 import org.apache.cassandra.net.Message;
 import org.apache.cassandra.net.Verb;
 import org.apache.cassandra.schema.ColumnMetadata;
 import org.apache.cassandra.schema.TableMetadata;
+import org.apache.cassandra.service.accord.AccordKeyspace;
 import org.apache.cassandra.service.accord.AccordService;
 import org.apache.cassandra.service.accord.AccordTxnBuilder;
 import org.apache.cassandra.service.accord.db.AccordData;
 import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.cassandra.utils.Clock;
+import org.apache.cassandra.utils.FailingConsumer;
 import org.assertj.core.api.Assertions;
 
 import static org.apache.cassandra.service.accord.db.AccordUpdate.UpdatePredicate.Type.EQUAL;
 import static org.apache.cassandra.service.accord.db.AccordUpdate.UpdatePredicate.Type.NOT_EXISTS;
+import static org.apache.cassandra.utils.Clock.Global.nanoTime;
 
 //TODO there are too many new clusters, this will cause Metaspace issues.  Once Schema and topology are integrated, can switch
 // to a shared cluster with isolated tables
 public class AccordIntegrationTest extends TestBaseImpl
 {
+    private static final Logger logger = LoggerFactory.getLogger(AccordIntegrationTest.class);
+
     private static final String keyspace = "ks";
 
     private static void assertRow(Cluster cluster, String query, int k, int c, int v)
@@ -81,7 +95,7 @@ public class AccordIntegrationTest extends TestBaseImpl
                                                    .build());
     }
 
-    private static void test(Consumer<Cluster> fn) throws IOException
+    private static void test(FailingConsumer<Cluster> fn) throws IOException
     {
         try (Cluster cluster = createCluster())
         {
@@ -186,7 +200,7 @@ public class AccordIntegrationTest extends TestBaseImpl
     }
 
     @Test
-    public void multipleShards() throws IOException
+    public void multipleShards() throws IOException, TimeoutException
     {
         // can't reuse test() due to it using "int" for pk; this test needs "blob"
         try (Cluster cluster = createCluster())
@@ -276,14 +290,32 @@ public class AccordIntegrationTest extends TestBaseImpl
         });
     }
 
-    private static void awaitAsyncApply(Cluster cluster)
+    private static void awaitAsyncApply(Cluster cluster) throws TimeoutException
     {
-        //TODO figure out a way to block so tests can be stable
-        // I tried to check the stores but you have to be in the correct threads and we attempt to load from table but this isn't updated
-        //TODO can't send PreAccept as we don't know the Keys (empty tx)
-//        cluster.get(1).runOnInstance(() -> execute(txn())); // TODO why does this hang?
-
-        Uninterruptibles.sleepUninterruptibly(10, TimeUnit.SECONDS);
+        long deadlineNanos = nanoTime() + TimeUnit.SECONDS.toNanos(1);
+        AtomicReference<TimeoutException> timeout = new AtomicReference<>(null);
+        cluster.stream().filter(i -> !i.isShutdown()).forEach(inst -> {
+            while (timeout.get() == null)
+            {
+                SimpleQueryResult pending = inst.executeInternalWithResult("SELECT store_generation, store_index, txn_id, status FROM system_accord.commands WHERE status < ? ALLOW FILTERING", Status.Executed.ordinal());
+                pending = QueryResultUtil.map(pending,
+                                              "txn_id", (ByteBuffer bb) -> AccordKeyspace.deserializeTimestampOrNull(bb, TxnId::new),
+                                              "status", (Integer ordinal) -> Status.values()[ordinal]);
+                logger.info("[node{}] Pending:\n{}", inst.config().num(), QueryResultUtil.expand(pending));
+                pending.reset();
+                if (!pending.hasNext())
+                    break;
+                if (nanoTime() > deadlineNanos)
+                {
+                    pending.reset();
+                    timeout.set(new TimeoutException("Timeout waiting on Accord Txn to complete; node" + inst.config().num() + " Pending:\n" + QueryResultUtil.expand(pending)));
+                    break;
+                }
+                Uninterruptibles.sleepUninterruptibly(500, TimeUnit.MILLISECONDS);
+            }
+        });
+        if (timeout.get() != null)
+            throw timeout.get();
     }
 
     private static AccordTxnBuilder txn()

--- a/test/distributed/org/apache/cassandra/distributed/test/accord/AccordIntegrationTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/accord/AccordIntegrationTest.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.concurrent.ExecutionException;
@@ -296,9 +297,10 @@ public class AccordIntegrationTest extends TestBaseImpl
             while (timeout.get() == null)
             {
                 SimpleQueryResult pending = inst.executeInternalWithResult("SELECT store_generation, store_index, txn_id, status FROM system_accord.commands WHERE status < ? ALLOW FILTERING", Status.Executed.ordinal());
-                pending = QueryResultUtil.map(pending,
-                                              "txn_id", (ByteBuffer bb) -> AccordKeyspace.deserializeTimestampOrNull(bb, TxnId::new),
-                                              "status", (Integer ordinal) -> Status.values()[ordinal]);
+                pending = QueryResultUtil.map(pending, Map.of(
+                "txn_id", (ByteBuffer bb) -> AccordKeyspace.deserializeTimestampOrNull(bb, TxnId::new),
+                "status", (Integer ordinal) -> Status.values()[ordinal]
+                ));
                 logger.info("[node{}] Pending:\n{}", inst.config().num(), QueryResultUtil.expand(pending));
                 pending.reset();
                 if (!pending.hasNext())

--- a/test/distributed/org/apache/cassandra/distributed/util/QueryResultUtil.java
+++ b/test/distributed/org/apache/cassandra/distributed/util/QueryResultUtil.java
@@ -73,7 +73,7 @@ public class QueryResultUtil
             };
             rows[i] = row;
         }
-        return new SimpleQueryResult(input.names().toArray(new String[0]), rows, input.warnings());
+        return new SimpleQueryResult(input.names().toArray(String[]::new), rows, input.warnings());
     }
 
     public static boolean contains(SimpleQueryResult qr, Object... values)

--- a/test/distributed/org/apache/cassandra/distributed/util/QueryResultUtil.java
+++ b/test/distributed/org/apache/cassandra/distributed/util/QueryResultUtil.java
@@ -36,21 +36,8 @@ public class QueryResultUtil
     {
     }
 
-    public static <A> SimpleQueryResult map(SimpleQueryResult input,
-                                            String c1, Function<A, Object> c1Fn)
-    {
-        return map(input, Map.of(c1, (Function<Object, Object>) c1Fn));
-    }
-
-    public static <A, B> SimpleQueryResult map(SimpleQueryResult input,
-                                               String c1, Function<A, Object> c1Fn,
-                                               String c2, Function<B, Object> c2Fn)
-    {
-        return map(input, Map.of(c1, (Function<Object, Object>) c1Fn,
-                                 c2, (Function<Object, Object>) c2Fn));
-    }
-
-    public static SimpleQueryResult map(SimpleQueryResult input, Map<String, Function<Object, Object>> mapper)
+    @SuppressWarnings("unchecked")
+    public static SimpleQueryResult map(SimpleQueryResult input, Map<String, ? extends Function<?, Object>> mapper)
     {
         if (input.toObjectArrays().length == 0 || mapper == null || mapper.isEmpty())
             return input;
@@ -67,10 +54,10 @@ public class QueryResultUtil
             Object[] row = rows[i].clone();
             for (int j = 0; j < idxes.length; j++)
             {
-                Function<Object, Object> map = mapper.get(names.get(j));
+                @SuppressWarnings("rawtypes") Function map = mapper.get(names.get(j));
                 int idx = idxes[j];
                 row[idx] = map.apply(row[idx]);
-            };
+            }
             rows[i] = row;
         }
         return new SimpleQueryResult(input.names().toArray(String[]::new), rows, input.warnings());

--- a/test/distributed/org/apache/cassandra/distributed/util/QueryResultUtil.java
+++ b/test/distributed/org/apache/cassandra/distributed/util/QueryResultUtil.java
@@ -36,14 +36,15 @@ public class QueryResultUtil
     {
     }
 
-    public static <A> SimpleQueryResult map(SimpleQueryResult input, String c1, Function<A, Object> c1Fn)
+    public static <A> SimpleQueryResult map(SimpleQueryResult input,
+                                            String c1, Function<A, Object> c1Fn)
     {
         return map(input, Map.of(c1, (Function<Object, Object>) c1Fn));
     }
 
     public static <A, B> SimpleQueryResult map(SimpleQueryResult input,
-                                        String c1, Function<A, Object> c1Fn,
-                                        String c2, Function<B, Object> c2Fn)
+                                               String c1, Function<A, Object> c1Fn,
+                                               String c2, Function<B, Object> c2Fn)
     {
         return map(input, Map.of(c1, (Function<Object, Object>) c1Fn,
                                  c2, (Function<Object, Object>) c2Fn));

--- a/test/distributed/org/apache/cassandra/distributed/util/QueryResultUtil.java
+++ b/test/distributed/org/apache/cassandra/distributed/util/QueryResultUtil.java
@@ -17,8 +17,12 @@
  */
 package org.apache.cassandra.distributed.util;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.function.Function;
 import java.util.function.Predicate;
 
 import org.apache.cassandra.distributed.api.Row;
@@ -30,6 +34,45 @@ public class QueryResultUtil
 {
     private QueryResultUtil()
     {
+    }
+
+    public static <A> SimpleQueryResult map(SimpleQueryResult input, String c1, Function<A, Object> c1Fn)
+    {
+        return map(input, Map.of(c1, (Function<Object, Object>) c1Fn));
+    }
+
+    public static <A, B> SimpleQueryResult map(SimpleQueryResult input,
+                                        String c1, Function<A, Object> c1Fn,
+                                        String c2, Function<B, Object> c2Fn)
+    {
+        return map(input, Map.of(c1, (Function<Object, Object>) c1Fn,
+                                 c2, (Function<Object, Object>) c2Fn));
+    }
+
+    public static SimpleQueryResult map(SimpleQueryResult input, Map<String, Function<Object, Object>> mapper)
+    {
+        if (input.toObjectArrays().length == 0 || mapper == null || mapper.isEmpty())
+            return input;
+        for (String name : mapper.keySet())
+        {
+            if (!input.names().contains(name))
+                throw new IllegalArgumentException("Unable to find column " + name);
+        }
+        Object[][] rows = input.toObjectArrays().clone();
+        List<String> names = new ArrayList<>(mapper.keySet());
+        int[] idxes = names.stream().mapToInt(input.names()::indexOf).toArray();
+        for (int i = 0; i < rows.length; i++)
+        {
+            Object[] row = rows[i].clone();
+            for (int j = 0; j < idxes.length; j++)
+            {
+                Function<Object, Object> map = mapper.get(names.get(j));
+                int idx = idxes[j];
+                row[idx] = map.apply(row[idx]);
+            };
+            rows[i] = row;
+        }
+        return new SimpleQueryResult(input.names().toArray(new String[0]), rows, input.warnings());
     }
 
     public static boolean contains(SimpleQueryResult qr, Object... values)


### PR DESCRIPTION
```
Caused by: java.util.concurrent.TimeoutException: Timeout waiting on Accord Txn to complete; node1 Pending:
@ Row 1
store_generation|0                                       
store_index     |1                                       
txn_id          |[1,1661882626579000,0,12700000000107012]
status          |ReadyToExecute                          

	at org.apache.cassandra.distributed.test.accord.AccordIntegrationTest.lambda$awaitAsyncApply$17(AccordIntegrationTest.java:309)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:183)
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:177)
	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1655)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
	at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:497)
	at org.apache.cassandra.distributed.test.accord.AccordIntegrationTest.awaitAsyncApply(AccordIntegrationTest.java:295)
```