### PR TITLE
KeySerializers.key can get any type of key and not just partition key, so use the AccordKey.serializer

### DIFF
--- a/src/java/org/apache/cassandra/service/accord/serializers/KeySerializers.java
+++ b/src/java/org/apache/cassandra/service/accord/serializers/KeySerializers.java
@@ -28,6 +28,7 @@ import org.apache.cassandra.db.TypeSizes;
 import org.apache.cassandra.io.IVersionedSerializer;
 import org.apache.cassandra.io.util.DataInputPlus;
 import org.apache.cassandra.io.util.DataOutputPlus;
+import org.apache.cassandra.schema.Schema;
 import org.apache.cassandra.service.accord.TokenRange;
 import org.apache.cassandra.service.accord.api.AccordKey;
 
@@ -35,26 +36,7 @@ public class KeySerializers
 {
     private KeySerializers() {}
 
-    public static final IVersionedSerializer<Key> key = new IVersionedSerializer<>()
-    {
-        @Override
-        public void serialize(Key key, DataOutputPlus out, int version) throws IOException
-        {
-            AccordKey.PartitionKey.serializer.serialize((AccordKey.PartitionKey) key, out, version);
-        }
-
-        @Override
-        public Key deserialize(DataInputPlus in, int version) throws IOException
-        {
-            return AccordKey.PartitionKey.serializer.deserialize(in, version);
-        }
-
-        @Override
-        public long serializedSize(Key key, int version)
-        {
-            return AccordKey.PartitionKey.serializer.serializedSize((AccordKey.PartitionKey) key, version);
-        }
-    };
+    public static final IVersionedSerializer<Key> key = (IVersionedSerializer<Key>) (IVersionedSerializer<?>) AccordKey.serializer;
 
     public static final IVersionedSerializer<Keys> keys = new IVersionedSerializer<>()
     {

--- a/test/distributed/org/apache/cassandra/distributed/test/accord/AccordIntegrationTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/accord/AccordIntegrationTest.java
@@ -55,6 +55,7 @@ import org.apache.cassandra.db.rows.Row;
 import org.apache.cassandra.dht.Murmur3Partitioner;
 import org.apache.cassandra.distributed.Cluster;
 import org.apache.cassandra.distributed.api.ConsistencyLevel;
+import org.apache.cassandra.distributed.api.Feature;
 import org.apache.cassandra.distributed.api.IMessageFilters;
 import org.apache.cassandra.distributed.api.QueryResults;
 import org.apache.cassandra.distributed.api.SimpleQueryResult;
@@ -110,7 +111,7 @@ public class AccordIntegrationTest extends TestBaseImpl
     private static Cluster createCluster() throws IOException
     {
         // need to up the timeout else tests get flaky
-        return init(Cluster.build(2).withConfig(c -> c.set("write_request_timeout_in_ms", TimeUnit.SECONDS.toMillis(10))).start());
+        return init(Cluster.build(2).withConfig(c -> c.with(Feature.NETWORK).set("write_request_timeout_in_ms", TimeUnit.SECONDS.toMillis(10))).start());
     }
 
     @Test


### PR DESCRIPTION
```
cassauto_cassandra_user_admin@cqlsh> BEGIN TRANSACTION
   ... LET r = (SELECT * FROM tlp_stress.tx_accord_counter WHERE id='does not exist');
   ... SELECT r.value;
   ... COMMIT TRANSACTION;
NoHostAvailable: ('Unable to complete the operation against any hosts', {<Host: 100.109.33.1:9042 DC1>: <Error from server: code=0000 [Server error] message="java.lang.ClassCastException: class org.apache.cassandra.service.accord.api.AccordKey$TokenKey cannot be cast to class org.apache.cassandra.service.accord.api.AccordKey$PartitionKey (org.apache.cassandra.service.accord.api.AccordKey$TokenKey and org.apache.cassandra.service.accord.api.AccordKey$PartitionKey are in unnamed module of loader 'app')">})
```

```
22:43:22.784 [Native-Transport-Requests-1] ERROR org.apache.cassandra.transport.messages.ErrorMessage - Unexpected exception during request
java.lang.ClassCastException: class org.apache.cassandra.service.accord.api.AccordKey$TokenKey cannot be cast to class org.apache.cassandra.service.accord.api.AccordKey$PartitionKey (org.apache.cassandra.service.accord.api.AccordKey$TokenKey and
 org.apache.cassandra.service.accord.api.AccordKey$PartitionKey are in unnamed module of loader 'app')
        at org.apache.cassandra.service.accord.serializers.KeySerializers$1.serializedSize(KeySerializers.java:55)
        at org.apache.cassandra.service.accord.serializers.KeySerializers$1.serializedSize(KeySerializers.java:39)
        at org.apache.cassandra.service.accord.serializers.KeySerializers$2.serializedSize(KeySerializers.java:83)
        at org.apache.cassandra.service.accord.serializers.KeySerializers$2.serializedSize(KeySerializers.java:60)
        at org.apache.cassandra.service.accord.serializers.TxnRequestSerializer.serializedHeaderSize(TxnRequestSerializer.java:60)
        at org.apache.cassandra.service.accord.serializers.TxnRequestSerializer$WithUnsyncedSerializer.serializedHeaderSize(TxnRequestSerializer.java:94)
        at org.apache.cassandra.service.accord.serializers.TxnRequestSerializer$WithUnsyncedSerializer.serializedHeaderSize(TxnRequestSerializer.java:71)
        at org.apache.cassandra.service.accord.serializers.TxnRequestSerializer.serializedSize(TxnRequestSerializer.java:68)
        at org.apache.cassandra.service.accord.serializers.TxnRequestSerializer$WithUnsyncedSerializer.serializedSize(TxnRequestSerializer.java:71)
        at org.apache.cassandra.net.Message$Serializer.payloadSize(Message.java:1397)
        at org.apache.cassandra.net.Message.payloadSize(Message.java:1463)
        at org.apache.cassandra.net.Message$Serializer.serializedSizePost40(Message.java:868)
        at org.apache.cassandra.net.Message$Serializer.serializedSize(Message.java:725)
        at org.apache.cassandra.net.Message.serializedSize(Message.java:1438)
        at org.apache.cassandra.net.OutboundConnections.connectionTypeFor(OutboundConnections.java:212)
        at org.apache.cassandra.net.OutboundConnections.connectionFor(OutboundConnections.java:204)
        at org.apache.cassandra.net.OutboundConnections.enqueue(OutboundConnections.java:93)
        at org.apache.cassandra.net.MessagingService.doSend(MessagingService.java:416)
        at org.apache.cassandra.net.OutboundSink.accept(OutboundSink.java:70)
        at org.apache.cassandra.net.MessagingService.send(MessagingService.java:405)
        at org.apache.cassandra.net.MessagingService.sendWithCallback(MessagingService.java:345)
        at org.apache.cassandra.net.MessagingService.sendWithCallback(MessagingService.java:337)
        at org.apache.cassandra.service.accord.AccordMessageSink.send(AccordMessageSink.java:107)
        at accord.local.Node.send(Node.java:357)
        at accord.local.Node.lambda$send$10(Node.java:351)
        at java.base/java.util.HashMap$KeySet.forEach(HashMap.java:929)
        at accord.local.Node.send(Node.java:351)
        at accord.coordinate.Coordinate.start(Coordinate.java:155)
        at accord.coordinate.Coordinate.coordinate(Coordinate.java:161)
        at accord.local.Node.initiateCoordination(Node.java:403)
        at accord.local.Node.lambda$coordinate$11(Node.java:388)
        at accord.local.Node.withEpoch(Node.java:194)
        at accord.local.Node.coordinate(Node.java:388)
        at accord.local.Node.coordinate(Node.java:380)
        at org.apache.cassandra.service.accord.AccordService.coordinate(AccordService.java:102)
        at org.apache.cassandra.service.StorageProxy.txn(StorageProxy.java:2320)
        at org.apache.cassandra.cql3.statements.TransactionStatement.execute(TransactionStatement.java:198)
        at org.apache.cassandra.cql3.QueryProcessor.processStatement(QueryProcessor.java:258)
        at org.apache.cassandra.cql3.QueryProcessor.process(QueryProcessor.java:351)
        at org.apache.cassandra.cql3.QueryProcessor.process(QueryProcessor.java:338)
        at org.apache.cassandra.transport.messages.QueryMessage.execute(QueryMessage.java:116)
        at org.apache.cassandra.transport.Message$Request.execute(Message.java:255)
        at org.apache.cassandra.transport.Dispatcher.processRequest(Dispatcher.java:194)
        at org.apache.cassandra.transport.Dispatcher.processRequest(Dispatcher.java:213)
        at org.apache.cassandra.transport.Dispatcher.processRequest(Dispatcher.java:240)
        at org.apache.cassandra.transport.Dispatcher$RequestProcessor.run(Dispatcher.java:137)
        at org.apache.cassandra.concurrent.FutureTask$1.call(FutureTask.java:96)
        at org.apache.cassandra.concurrent.FutureTask.call(FutureTask.java:61)
        at org.apache.cassandra.concurrent.FutureTask.run(FutureTask.java:71)
        at org.apache.cassandra.concurrent.SEPWorker.run(SEPWorker.java:142)
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
        at java.base/java.lang.Thread.run(Thread.java:829)
```